### PR TITLE
Add ZubanLS venv detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /out
+*.vsix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Resolve `zuban` from the Python extension’s active environment (including **Select Interpreter**), with settings and `PATH` fallbacks; optional `zubanls.executablePath`; restart when the environment or relevant settings change.
+
 ## 0.0.1
 
 Initial release

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,3 +29,9 @@ nvm use 20
 ## Test the release locally in VSCode
 
 code --install-extension zubanls-x.x.x.vsix
+
+## Run the extension from source (F5)
+
+1. `npm install` and `npm run compile` (or `npm run watch` in a terminal).
+2. Open this folder in VS Code / Cursor and run **Run Extension** from the Run and Debug view.
+3. In the Extension Development Host window, open a Python workspace where `zuban` is installed in the same `venv` as the selected interpreter; open **View → Output → ZubanLS** and confirm the `Zuban: …` line points at the binary you expect.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ The extension needs to have `zuban` installed. It can be installed with:
 pip install zuban --break-system-packages --upgrade
 ```
 
+Install it into the same environment as your project (for example your virtual environment) so the language server can resolve imports the same way your tests and runtime do.
+
+## Virtual environments
+
+By default, when **ZubanLS: Executable Path** is empty, the extension picks `zuban` in this order:
+
+1. **Selected environment from the Python extension** ([Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)) — matches **Python: Select Interpreter** and restarts when that environment changes.
+2. Otherwise **Python: Default Interpreter Path** in settings (same folder as that interpreter’s `python` / `python.exe`).
+3. Otherwise `zuban` on your `PATH`.
+
+If the Python extension is not installed, only steps 2 and 3 apply.
+
+You can set **ZubanLS: Executable Path** to an absolute path to force a specific `zuban` binary.
+
 ## Documentation
 
 Go to https://docs.zubanls.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "zubanls",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zubanls",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
+        "@vscode/python-extension": "^1.0.6",
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
@@ -626,6 +627,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vscode/python-extension": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/python-extension/-/python-extension-1.0.6.tgz",
+      "integrity": "sha512-q7KYf+mymM67G0yS6xfhczFwu2teBi5oXHVdNgtCsYhErdSOkwMPtE291SqQahrjTcgKxn7O56i1qb1EQR6o4w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.17.0",
+        "vscode": "^1.93.0"
       }
     },
     "node_modules/@vscode/test-cli": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,18 @@
       "description": "In virtual workspaces, resolving imports might not be possible."
     }
   },
+  "contributes": {
+    "configuration": {
+      "title": "ZubanLS",
+      "properties": {
+        "zubanls.executablePath": {
+          "type": "string",
+          "default": "",
+          "description": "Absolute path to the zuban executable. When empty, ZubanLS resolves zuban next to the selected Python interpreter if that binary exists, otherwise falls back to zuban on PATH."
+        }
+      }
+    }
+  },
   "main": "./out/extension.js",
   "scripts": {
     "vscode:prepublish": "npm run compile",
@@ -76,6 +88,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
+    "@vscode/python-extension": "^1.0.6",
     "vscode-languageclient": "^9.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zubanls",
   "displayName": "ZubanLS",
   "description": "A very fast, low-memory Python Language Server built in Rust",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "engines": {
     "vscode": "^1.74.0"
   },
@@ -90,5 +90,8 @@
   "dependencies": {
     "@vscode/python-extension": "^1.0.6",
     "vscode-languageclient": "^9.0.1"
-  }
+  },
+  "extensionDependencies": [
+		"ms-python.python"
+	]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,39 +1,104 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import * as vscode from 'vscode';
-import {
-  LanguageClient,
-  LanguageClientOptions,
-  ServerOptions,
-} from 'vscode-languageclient/node';
+import { PythonExtension } from '@vscode/python-extension';
+import { LanguageClient, LanguageClientOptions } from 'vscode-languageclient/node';
 
-let client: LanguageClient;
+const outputChannel = vscode.window.createOutputChannel('ZubanLS');
+let client: LanguageClient | undefined;
+const clientOptions: LanguageClientOptions = {
+  documentSelector: [
+    { scheme: 'file', language: 'python' },
+    { scheme: 'vscode-notebook-cell', language: 'python' },
+  ],
+  outputChannel,
+};
 
-export function activate() {
-  const serverOptions: ServerOptions = {
-    command: "zuban",
-    args: ["server"],
-  };
+let pythonApi: Awaited<ReturnType<typeof PythonExtension.api>> | undefined;
 
-  const clientOptions: LanguageClientOptions = {
-    documentSelector: [
-        { scheme: 'file', language: 'python' },
-        { scheme: 'vscode-notebook-cell', language: 'python' }
-    ],
-  };
+async function ensurePythonApi(): Promise<void> {
+  if (pythonApi) {
+    return;
+  }
+  try {
+    pythonApi = await PythonExtension.api();
+    await pythonApi.ready;
+  } catch {
+    pythonApi = undefined;
+  }
+}
 
-  client = new LanguageClient(
-    'zuban',
-    'Zuban',
-    serverOptions,
-    clientOptions
+async function resolveServerOptions(): Promise<{ command: string; args: string[] }> {
+  const r =
+    vscode.window.activeTextEditor?.document.uri ?? vscode.workspace.workspaceFolders?.[0]?.uri;
+  const ex = vscode.workspace.getConfiguration('zubanls', r).get<string>('executablePath')?.trim();
+  if (ex) {
+    return { command: ex, args: ['server'] };
+  }
+
+  const zubanBin = process.platform === 'win32' ? 'zuban.exe' : 'zuban';
+  await ensurePythonApi();
+  if (pythonApi) {
+    try {
+      const ep = pythonApi.environments.getActiveEnvironmentPath(r);
+      const resolved = await pythonApi.environments.resolveEnvironment(ep);
+      const dirs: string[] = [];
+      if (resolved?.executable.uri?.fsPath) {
+        dirs.push(path.dirname(resolved.executable.uri.fsPath));
+      }
+      if (ep.path) {
+        dirs.push(path.join(ep.path, process.platform === 'win32' ? 'Scripts' : 'bin'));
+      }
+      for (const d of dirs) {
+        const full = path.join(d, zubanBin);
+        if (fs.existsSync(full)) {
+          return { command: full, args: ['server'] };
+        }
+      }
+    } catch {
+      /* use settings / PATH */
+    }
+  }
+
+  const py = vscode.workspace.getConfiguration('python', r).get<string>('defaultInterpreterPath')?.trim();
+  if (py) {
+    const full = path.join(path.dirname(py), zubanBin);
+    if (fs.existsSync(full)) {
+      return { command: full, args: ['server'] };
+    }
+  }
+  return { command: 'zuban', args: ['server'] };
+}
+
+async function start(): Promise<void> {
+  if (client) {
+    await client.stop();
+  }
+  const opts = await resolveServerOptions();
+  outputChannel.appendLine(`Zuban: ${opts.command}`);
+  client = new LanguageClient('zuban', 'Zuban', opts, clientOptions);
+  await client.start();
+}
+
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  await start();
+  if (pythonApi) {
+    context.subscriptions.push(
+      pythonApi.environments.onDidChangeActiveEnvironmentPath(() => {
+        void start();
+      }),
+    );
+  }
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration('zubanls') || e.affectsConfiguration('python')) {
+        void start();
+      }
+    }),
+    outputChannel,
   );
-
-  client.start();
 }
 
 export function deactivate(): Thenable<void> | undefined {
-  if (!client) {
-    return undefined;
-  }
-  return client.stop();
+  return client?.stop();
 }
-

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,15 +28,21 @@ async function ensurePythonApi(): Promise<void> {
   }
 }
 
-async function resolveServerOptions(): Promise<{ command: string; args: string[] }> {
+async function resolveServerOptions(): Promise<string> {
+  const zubanBin = process.platform === 'win32' ? 'zuban.exe' : 'zuban';
+
+  // Step 1: Check the zubanls.executablePath
   const r =
     vscode.window.activeTextEditor?.document.uri ?? vscode.workspace.workspaceFolders?.[0]?.uri;
   const ex = vscode.workspace.getConfiguration('zubanls', r).get<string>('executablePath')?.trim();
   if (ex) {
-    return { command: ex, args: ['server'] };
+    if (fs.existsSync(ex)) {
+      return ex;
+    }
+    vscode.window.showWarningMessage(`ZubanLS executable not found at zubanls.executablePath=${ex}`);
   }
 
-  const zubanBin = process.platform === 'win32' ? 'zuban.exe' : 'zuban';
+  // Step 2: Search in the Python extension's environment
   await ensurePythonApi();
   if (pythonApi) {
     try {
@@ -52,7 +58,7 @@ async function resolveServerOptions(): Promise<{ command: string; args: string[]
       for (const d of dirs) {
         const full = path.join(d, zubanBin);
         if (fs.existsSync(full)) {
-          return { command: full, args: ['server'] };
+          return full;
         }
       }
     } catch {
@@ -60,24 +66,32 @@ async function resolveServerOptions(): Promise<{ command: string; args: string[]
     }
   }
 
+  // Step 3: Search in the python.defaultInterpreterPath
   const py = vscode.workspace.getConfiguration('python', r).get<string>('defaultInterpreterPath')?.trim();
   if (py) {
     const full = path.join(path.dirname(py), zubanBin);
     if (fs.existsSync(full)) {
-      return { command: full, args: ['server'] };
+      return full;
     }
   }
-  return { command: 'zuban', args: ['server'] };
+
+  // Step 4: Rely on PATH
+  return 'zuban';
 }
 
 async function start(): Promise<void> {
   if (client) {
     await client.stop();
   }
-  const opts = await resolveServerOptions();
-  outputChannel.appendLine(`Zuban: ${opts.command}`);
-  client = new LanguageClient('zuban', 'Zuban', opts, clientOptions);
-  await client.start();
+  const command = await resolveServerOptions();
+  outputChannel.appendLine(`Zuban: ${command}`);
+  client = new LanguageClient('zuban', 'Zuban', { command, args: ['server'] }, clientOptions);
+  try {
+    await client.start();
+  } catch (e) {
+    vscode.window.showErrorMessage(`Failed to start ZubanLS: ${e instanceof Error ? e.message : e}`);
+    client = undefined;
+  }
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {


### PR DESCRIPTION
Resolve `zuban` from the Python extension’s active environment (including **Select Interpreter**), with settings and `PATH` fallbacks; optional `zubanls.executablePath`; restart when the environment or relevant settings change.